### PR TITLE
fix: enable go install support with BuddhiLW/bonzai fork

### DIFF
--- a/cmd/lazywal-mcp/main.go
+++ b/cmd/lazywal-mcp/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/BuddhiLW/lazywal/loop"
 	"github.com/mark3labs/mcp-go/server"
-	bmcp "github.com/rwxrob/bonzai/mcp"
+	bmcp "github.com/BuddhiLW/bonzai/mcp"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/BuddhiLW/lazywal
 go 1.23.4
 
 require (
+	github.com/BuddhiLW/bonzai v0.57.1-mcp
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.43.2
-	github.com/rwxrob/bonzai v0.20.10
-	github.com/rwxrob/bonzai/persisters/injson v0.1.0
+	github.com/rwxrob/bonzai/persisters/injson v0.3.0
 )
 
 require (
@@ -22,9 +22,3 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/rwxrob/bonzai => /home/lages/PP/bonzai
-
-replace github.com/rwxrob/bonzai/persisters/injson => /home/lages/PP/bonzai/persisters/injson
-
-replace github.com/rwxrob/bonzai/futil => /home/lages/PP/bonzai/futil

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BuddhiLW/bonzai v0.57.1-mcp h1:K59pYo604kwVuncUrNQDbZiWRlz2O60zELTsCwBja70=
+github.com/BuddhiLW/bonzai v0.57.1-mcp/go.mod h1:XQZBYM9fP/D6v0hPGY0EATG5b7TtCOKyQaox0wu5fO0=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -25,6 +27,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/rwxrob/bonzai/futil v0.3.0 h1:zShASzw32e/4ZPPvF1nbFWgbj3UWHfb5nFBIw+3Bu6s=
+github.com/rwxrob/bonzai/futil v0.3.0/go.mod h1:wobk3a1WuYjgqYZ+ezbjNupCpqaYceF2441M/FSm9GM=
+github.com/rwxrob/bonzai/persisters/injson v0.3.0 h1:0v2Wla2jgcEnp3F2S385l+GnRwlq3nR7R+WcnkEVemk=
+github.com/rwxrob/bonzai/persisters/injson v0.3.0/go.mod h1:hrkAMwAuGiNVJcD3+oRbToOUBmo2JuIU6Lu/Fwgpo6s=
 github.com/rwxrob/bonzai/uniq v0.1.0 h1:xOlTWnaotslv1I0Nc+3+qXHxecoxNSROo871S2m3cq4=
 github.com/rwxrob/bonzai/uniq v0.1.0/go.mod h1:RsSPso5Dhs1tYEjhuVA4b8DM5l0pQPhGebm8Lx5XHc8=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=

--- a/internal/check/dependencies.go
+++ b/internal/check/dependencies.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/BuddhiLW/lazywal/config"
-	"github.com/rwxrob/bonzai"
+	"github.com/BuddhiLW/bonzai"
 )
 
 const (

--- a/loop/clear.go
+++ b/loop/clear.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/rwxrob/bonzai"
+	"github.com/BuddhiLW/bonzai"
 )
 
 var ClearCmd = &bonzai.Cmd{

--- a/loop/cmd.go
+++ b/loop/cmd.go
@@ -54,7 +54,7 @@ var HelpCmd = &bonzai.Cmd{
 var Cmd = &bonzai.Cmd{
 	Name:  `lazywal`,
 	Short: `video/gif wallpaper client`,
-	Vers:  `v1.3.0`,
+	Vers:  `v1.4.0`,
 
 	Cmds: []*bonzai.Cmd{
 		HelpCmd,

--- a/loop/cmd.go
+++ b/loop/cmd.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	dependencies "github.com/BuddhiLW/lazywal/internal/check"
-	"github.com/rwxrob/bonzai"
+	"github.com/BuddhiLW/bonzai"
 )
 
 // showHelp displays help for the given command

--- a/loop/helpers.go
+++ b/loop/helpers.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rwxrob/bonzai"
+	"github.com/BuddhiLW/bonzai"
 )
 
 var execCommand = exec.Command

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 
 	dependencies "github.com/BuddhiLW/lazywal/internal/check"
-	"github.com/rwxrob/bonzai"
+	"github.com/BuddhiLW/bonzai"
 	"github.com/rwxrob/bonzai/persisters/injson"
 )
 


### PR DESCRIPTION
## Summary
- Remove local `replace` directives that blocked `go install ...@latest`
- Switch root bonzai dependency from `rwxrob/bonzai` to `BuddhiLW/bonzai v0.57.1-mcp`
- Upgrade `persisters/injson` to v0.3.0 for `NewUserState` API compatibility
- Bump version to v1.4.0

## Test plan
- [ ] `go install github.com/BuddhiLW/lazywal/cmd/lazywal@latest` works
- [ ] `go install github.com/BuddhiLW/lazywal/cmd/lazywal-mcp@latest` works
- [ ] `go test ./...` passes
- [ ] `go build ./cmd/lazywal/ && go build ./cmd/lazywal-mcp/` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)